### PR TITLE
Using ng-src instead src

### DIFF
--- a/src/js/app/intro/intro-header.html
+++ b/src/js/app/intro/intro-header.html
@@ -1,7 +1,7 @@
 <div class="intro-header">
-  <img src="img/{{img}}" />
+  <img ng-src="img/{{img}}" />
 
   <div class="intro-header-logo">
-    <img src="img/logo.png"/>
+    <img ng-src="img/logo.png"/>
   </div>
 </div>


### PR DESCRIPTION
"Using Angular markup like {{hash}} in a src attribute doesn't work right: The browser will fetch from the URL with the literal text {{hash}} until Angular replaces the expression inside {{hash}}. The ngSrc directive solves this problem."

https://docs.angularjs.org/api/ng/directive/ngSrc
